### PR TITLE
Added null check such that schemas that are null are ignored

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
@@ -457,11 +457,10 @@ public class AutodiscoverService extends ExchangeServiceBase
           redirectUrl.setParam(new URI(location));
 
           // Check if URL is SSL and that the path matches.
-          if ((redirectUrl.getParam().getScheme().toLowerCase()
-              .equals("https")) &&
-              (redirectUrl.getParam().getPath()
-                  .equalsIgnoreCase(
-                      AutodiscoverLegacyPath))) {
+          if (redirectUrl.getParam().getScheme() != null
+              && redirectUrl.getParam().getScheme().toLowerCase().equals("https")
+              && redirectUrl.getParam().getPath().equalsIgnoreCase(AutodiscoverLegacyPath))
+          {
             this.traceMessage(TraceFlags.AutodiscoverConfiguration,
                 String.format("Redirection URL found: '%s'",
                     redirectUrl.getParam().toString()));


### PR DESCRIPTION
some sites may not have a schema defined (such as //) which was breaking